### PR TITLE
Integrating cake i18n script with TwigView

### DIFF
--- a/Lib/Twig_Extension_I18n.php
+++ b/Lib/Twig_Extension_I18n.php
@@ -1,12 +1,5 @@
 <?php
 /**
- * Wrapper to __()
- */
-function cakeI18nFunction($var) {
-	return __($var);
-}
-
-/**
  * This file is part of Twig.
  *
  * (c) 2010 Fabien Potencier
@@ -36,7 +29,7 @@ class Twig_Extension_I18n extends Twig_Extension {
  * @return array An array of filters
  */
 	public function getFilters() {
-		return array('trans' => new Twig_Filter_Function('cakeI18nFunction'));
+		return array('trans' => new Twig_Filter_Function('__'));
 	}
 
 /**


### PR DESCRIPTION
Hi Graham,

As I talked with you by email, it would be nice to have a script to extract the strings used with the Twig trans filter. 

The cakephp "Console/cake i18n" script would be usable if a little change is done in the file Lib/Twig_Extension_I18n.php, changing the Twig_Filter_Function callback from cakeI18nFunction to __, using directly the cakephp internationalization function.

Regards, 

Jorge.
