### PR TITLE
Object being passed by reference

### DIFF
--- a/View/TwigView.php
+++ b/View/TwigView.php
@@ -126,7 +126,7 @@ class TwigView extends View {
 			$loaded_helpers = $this->Helpers->attached();
 			foreach($loaded_helpers as $helper) {
 				$name = Inflector::variable($helper);
-				$helpers[$name] =& $this->loadHelper($helper);
+				$helpers[$name] = $this->loadHelper($helper);
 			}
 
 			$data = array_merge($___dataForView, $helpers);	


### PR DESCRIPTION
Fix warning caused by assigning an object by reference: "Strict (2048): Only variables should be assigned by reference [APP\Plugin\TwigView\View\TwigView.php, line 129]"

Only applies to PHP5
