### PR TITLE
Fix override file extensions

### DIFF
--- a/View/TwigView.php
+++ b/View/TwigView.php
@@ -100,6 +100,7 @@ class TwigView extends View {
 		if (isset($Controller->theme)) {
 			$this->theme = $Controller->theme;
 		}
+		$this->ext = '.tpl';
 	}
 
 /**


### PR DESCRIPTION
$ext variable was overwrite by the constructor of the View.
https://github.com/cakephp/cakephp/blob/master/lib/Cake/View/View.php#L334

I was overwrite again $ext to the after the View constructor.
