### PR TITLE
Accepting null controller in constructor

### DIFF
--- a/View/TwigView.php
+++ b/View/TwigView.php
@@ -78,7 +78,7 @@ class TwigView extends View {
  *
  * @param Controller $Controller Controller
  */
-	public function __construct(Controller $Controller) {
+	public function __construct(Controller $Controller = null) {
 		$this->templatePaths = App::path('View');
 		$loader = new Twig_Loader_Filesystem($this->templatePaths[0]);
 		$this->Twig = new Twig_Environment($loader, array(


### PR DESCRIPTION
View should accept null in constructor without showing warnings. When rendering Emails for example, the View is initialized without a controller.
